### PR TITLE
Implement role-based routing

### DIFF
--- a/src/components/common/ProtectedRoute.jsx
+++ b/src/components/common/ProtectedRoute.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+
+const ProtectedRoute = ({ roles }) => {
+  const { user } = useAuth();
+
+  if (!user) {
+    return <Navigate to="/portal/login" replace />;
+  }
+
+  if (roles && !roles.includes(user.type)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,6 +1,35 @@
-import { useState } from 'react';
+import { createContext, useContext, useState } from 'react';
+import {
+  loginWithEmail,
+  logout as firebaseLogout,
+  registerPlanningUser,
+} from '../services/auth';
 
-export function useAuth() {
-    const [user, setUser] = useState(null);
-    return { user, setUser };
-} 
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+
+  const login = async (email, password, role) => {
+    await loginWithEmail(email, password);
+    setUser({ type: role, data: { email } });
+  };
+
+  const register = async (email, password) => {
+    await registerPlanningUser(email, password);
+    setUser({ type: 'planning', data: { email } });
+  };
+
+  const logout = async () => {
+    await firebaseLogout();
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, register, logout, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Calendar, User, Users } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import Header from '../components/common/Header';
 
-const HomePage = ({ onNavigate }) => {
+const HomePage = () => {
+  const navigate = useNavigate();
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
       <Header userType={null} />
@@ -29,7 +31,7 @@ const HomePage = ({ onNavigate }) => {
                 Consultez et modifiez votre rdv avec votre ID client ou QR code
               </p>
               <button
-                onClick={() => onNavigate('clientLogin')}
+                onClick={() => navigate('/client')}
                 className="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 transition"
               >
                 Accéder
@@ -48,7 +50,7 @@ const HomePage = ({ onNavigate }) => {
                 Gérez les rendez-vous et importez les données clients
               </p>
               <button
-                onClick={() => onNavigate('planningLogin')}
+                onClick={() => navigate('/portal/login')}
                 className="w-full bg-green-600 text-white py-3 rounded-lg font-semibold hover:bg-green-700 transition"
               >
                 Connexion
@@ -67,7 +69,7 @@ const HomePage = ({ onNavigate }) => {
                 Administration globale et validation des comptes
               </p>
               <button
-                onClick={() => onNavigate('adminLogin')}
+                onClick={() => navigate('/portal/login')}
                 className="w-full bg-purple-600 text-white py-3 rounded-lg font-semibold hover:bg-purple-700 transition"
               >
                 Connexion

--- a/src/pages/PlanningRegister.jsx
+++ b/src/pages/PlanningRegister.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+const PlanningRegister = () => {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await register(email, password);
+      navigate('/portal');
+    } catch (err) {
+      setError("Erreur lors de l'inscription");
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-lg shadow p-6 w-full max-w-sm space-y-4"
+      >
+        <h2 className="text-xl font-bold text-center">Inscription planning</h2>
+        <div>
+          <label className="block text-sm mb-1">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Mot de passe</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+          Créer le compte
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default PlanningRegister;

--- a/src/pages/PortalLogin.jsx
+++ b/src/pages/PortalLogin.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+const PortalLogin = () => {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('planning');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await login(email, password, role);
+      navigate('/portal');
+    } catch (err) {
+      setError('Erreur de connexion');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-lg shadow p-6 w-full max-w-sm space-y-4"
+      >
+        <h2 className="text-xl font-bold text-center">Connexion</h2>
+        <div>
+          <label className="block text-sm mb-1">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Mot de passe</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Rôle</label>
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="w-full border px-3 py-2 rounded"
+          >
+            <option value="planning">Service planification</option>
+            <option value="admin">Super admin</option>
+          </select>
+        </div>
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+          Se connecter
+        </button>
+        <p className="text-sm text-center">
+          <Link to="/portal/register" className="text-blue-600 hover:underline">
+            Créer un compte planning
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export default PortalLogin;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,2 +1,4 @@
 export { default as HomePage } from './HomePage';
-export { default as NotFound } from './NotFound'; 
+export { default as NotFound } from './NotFound';
+export { default as PortalLogin } from './PortalLogin';
+export { default as PlanningRegister } from './PlanningRegister';

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,4 +1,10 @@
-export const auth = {
-    login: (user) => Promise.resolve(`Logged in as ${user}`),
-    logout: () => Promise.resolve('Logged out'),
-}; 
+import { signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from 'firebase/auth';
+import { auth as firebaseAuth } from '../config/firebase';
+
+export const loginWithEmail = (email, password) =>
+  signInWithEmailAndPassword(firebaseAuth, email, password);
+
+export const registerPlanningUser = (email, password) =>
+  createUserWithEmailAndPassword(firebaseAuth, email, password);
+
+export const logout = () => signOut(firebaseAuth);


### PR DESCRIPTION
## Summary
- add firebase-based auth helpers
- expose login/register/logout via auth hook
- implement login page with firebase auth
- add registration page for planning service
- protect routes and handle logout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e94418c0c8327936c4fda3cbbbbe4